### PR TITLE
feat: always object binding on assignment

### DIFF
--- a/parser/src/expr.rs
+++ b/parser/src/expr.rs
@@ -11,7 +11,7 @@ use fajt_ast::{
 };
 use fajt_common::io::{PeekRead, ReReadWithState};
 use fajt_lexer::punct;
-use fajt_lexer::token::{Punctuator, Token, TokenValue};
+use fajt_lexer::token::{Token, TokenValue};
 use fajt_lexer::token_matches;
 use fajt_lexer::{keyword, LexerState};
 
@@ -61,29 +61,20 @@ where
                 self.parse_arrow_function_expr()
             }
             _ => {
-                // TODO if current is `{`, parse object or pattern
+                let start_token = self.current().cloned().unwrap();
+
                 let expr = self.parse_conditional_expr()?;
 
                 let assignment_operator = self.parse_optional_assignment_operator();
                 if let Some(operator) = assignment_operator {
                     expr.early_errors_left_hand_side_expr(&self.context, &operator)?;
 
-                    if matches!(
-                        expr,
-                        Expr::Literal(ExprLiteral {
-                            literal: Literal::Object(_),
-                            ..
-                        })
-                    ) {
-                        self.reader.rewind_to(&Token {
-                            value: TokenValue::Punctuator(Punctuator::BracketOpen),
-                            span: expr.span().clone(),
-                            first_on_line: false,
-                        })?;
-                        return self.parse_object_assignment_expr();
-                    }
+                    // This is not strictly necessary, but gives an easier to use api where the left
+                    // side of an assignment is always a binding pattern, and never object or array
+                    // literal.
+                    let left = self.reread_literal_as_binding_pattern(start_token, expr)?;
 
-                    self.parse_assignment(span_start, expr, operator)
+                    self.parse_assignment(span_start, left, operator)
                 } else {
                     // TODO validate object literal don't contain initializers, then it's not an object literal.
                     Ok(expr)
@@ -92,11 +83,26 @@ where
         }
     }
 
-    fn parse_object_assignment_expr(&mut self) -> Result<Expr> {
-        let span_start = self.position();
-        let object = self.parse_object_binding_pattern()?;
-        let operator = self.parse_optional_assignment_operator().unwrap(); // TODO
-        self.parse_assignment(span_start, Expr::Object(object), operator)
+    /// If the `expr` is an object literal, the stream is rewound to start_token and expect to
+    /// reread a object binding pattern.
+    fn reread_literal_as_binding_pattern(
+        &mut self,
+        start_token: Token,
+        expr: Expr,
+    ) -> Result<Expr> {
+        match expr {
+            Expr::Literal(ExprLiteral {
+                literal: Literal::Object(_),
+                ..
+            }) => {
+                self.reader.rewind_to(&start_token)?;
+
+                let object = self.parse_object_binding_pattern()?;
+                self.consume().unwrap(); // operator
+                Ok(Expr::Object(object))
+            }
+            _ => Ok(expr),
+        }
     }
 
     /// Parses the part of `AssignmentExpression` that starts with the `async` keyword.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate core;
 extern crate fajt_lexer;
 extern crate serde;
 

--- a/tests/cases/expr/assign/object-identifier.md
+++ b/tests/cases/expr/assign/object-identifier.md
@@ -15,20 +15,21 @@
     "span": "0:9",
     "operator": "Assign",
     "left": {
-      "Literal": {
+      "Object": {
         "span": "0:5",
-        "literal": {
-          "Object": {
-            "props": [
-              {
-                "IdentRef": {
-                  "span": "2:3",
-                  "name": "a"
-                }
-              }
-            ]
+        "props": [
+          {
+            "Single": {
+              "span": "2:3",
+              "ident": {
+                "span": "2:3",
+                "name": "a"
+              },
+              "initializer": null
+            }
           }
-        }
+        ],
+        "rest": null
       }
     },
     "right": {

--- a/tests/cases/expr/assign/object-rest-binding.md
+++ b/tests/cases/expr/assign/object-rest-binding.md
@@ -15,21 +15,12 @@
     "span": "0:12",
     "operator": "Assign",
     "left": {
-      "Literal": {
+      "Object": {
         "span": "0:8",
-        "literal": {
-          "Object": {
-            "props": [
-              {
-                "Spread": {
-                  "IdentRef": {
-                    "span": "5:6",
-                    "name": "a"
-                  }
-                }
-              }
-            ]
-          }
+        "props": [],
+        "rest": {
+          "span": "5:6",
+          "name": "a"
         }
       }
     },


### PR DESCRIPTION
Makes the AST more consistent and less cases to handle.

Previously:
```js
{ ...a } = b;  // Left side is object literal
{ a } = b;     // Left side is object literal
{ a = b } = c; // Left side is object binding (literal properties can't have an initializer)
```

Now:
```js
{ ...a } = b;  // Left side is object binding
{ a } = b;     // Left side is object binding
{ a = b } = c; // Left side is object binding
```