### PR TITLE
refactor: rename Expr::Object to Expr::ObjectBinding for more specificity

### DIFF
--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -20,7 +20,7 @@ ast_mapping! {
         Member(ExprMember),
         MetaProperty(ExprMetaProperty),
         New(ExprNew),
-        Object(ObjectBinding),
+        ObjectBinding(ObjectBinding),
         OptionalCall(ExprOptionalCall),
         OptionalMember(ExprOptionalMember),
         Parenthesized(ExprParenthesized),

--- a/ast/src/traverse/mod.rs
+++ b/ast/src/traverse/mod.rs
@@ -52,7 +52,7 @@ generate_fold_and_visit! {
             Member
             MetaProperty
             New
-            Object
+            ObjectBinding
             OptionalCall
             OptionalMember
             Parenthesized

--- a/parser/src/expr.rs
+++ b/parser/src/expr.rs
@@ -99,7 +99,7 @@ where
 
                 let object = self.parse_object_binding_pattern()?;
                 self.consume().unwrap(); // operator
-                Ok(Expr::Object(object))
+                Ok(Expr::ObjectBinding(object))
             }
             _ => Ok(expr),
         }

--- a/parser/src/literal.rs
+++ b/parser/src/literal.rs
@@ -175,7 +175,7 @@ where
                 && matches!(&prop, PropertyDefinition::IdentRef(_))
             {
                 self.reader.rewind_to(&start_token)?;
-                return Ok(Expr::Object(self.parse_object_binding_pattern()?));
+                return Ok(Expr::ObjectBinding(self.parse_object_binding_pattern()?));
             }
 
             props.push(prop);

--- a/parser/src/static_semantics/mod.rs
+++ b/parser/src/static_semantics/mod.rs
@@ -50,7 +50,7 @@ impl_trait!(
                     }) => {
                         return object.assert_covers_assignment_pattern();
                     }
-                    Expr::Object(object) => {
+                    Expr::ObjectBinding(object) => {
                         return object.assert_covers_assignment_pattern();
                     }
                     _ => {}

--- a/tests/cases/expr/assign/object-identifier.md
+++ b/tests/cases/expr/assign/object-identifier.md
@@ -15,7 +15,7 @@
     "span": "0:9",
     "operator": "Assign",
     "left": {
-      "Object": {
+      "ObjectBinding": {
         "span": "0:5",
         "props": [
           {

--- a/tests/cases/expr/assign/object-rest-binding.md
+++ b/tests/cases/expr/assign/object-rest-binding.md
@@ -15,7 +15,7 @@
     "span": "0:12",
     "operator": "Assign",
     "left": {
-      "Object": {
+      "ObjectBinding": {
         "span": "0:8",
         "props": [],
         "rest": {

--- a/tests/cases/expr/assign/object-with-initializer.md
+++ b/tests/cases/expr/assign/object-with-initializer.md
@@ -15,7 +15,7 @@
     "span": "0:13",
     "operator": "Assign",
     "left": {
-      "Object": {
+      "ObjectBinding": {
         "span": "0:9",
         "props": [
           {


### PR DESCRIPTION
The root level `Object` of an expression will always be an object binding as part of an assignment. Rename to be more clear.