### PR TITLE
feat: array binding pattern on assignment

### DIFF
--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -1,4 +1,4 @@
-use crate::binding::ObjectBinding;
+use crate::binding::{ArrayBinding, ObjectBinding};
 use crate::class::ExprClass;
 use crate::literal::*;
 use crate::{Body, FormalParameters, Ident, Span};
@@ -20,6 +20,7 @@ ast_mapping! {
         Member(ExprMember),
         MetaProperty(ExprMetaProperty),
         New(ExprNew),
+        ArrayBinding(ArrayBinding),
         ObjectBinding(ObjectBinding),
         OptionalCall(ExprOptionalCall),
         OptionalMember(ExprOptionalMember),

--- a/ast/src/traverse/mod.rs
+++ b/ast/src/traverse/mod.rs
@@ -38,6 +38,7 @@ generate_fold_and_visit! {
         }
 
         Expr: (enter: enter_expr, exit: exit_expr) {
+            ArrayBinding
             ArrowFunction
             Assignment
             Await

--- a/tests/cases/expr/assign/array-elision.md
+++ b/tests/cases/expr/assign/array-elision.md
@@ -5,7 +5,7 @@
 
 ### Output: minified
 ```js
-[]=a
+[,]=a
 ```
 
 ### Output: ast
@@ -15,15 +15,12 @@
     "span": "0:9",
     "operator": "Assign",
     "left": {
-      "Literal": {
+      "ArrayBinding": {
         "span": "0:5",
-        "literal": {
-          "Array": {
-            "elements": [
-              "Elision"
-            ]
-          }
-        }
+        "elements": [
+          null
+        ],
+        "rest": null
       }
     },
     "right": {

--- a/tests/cases/expr/assign/array-identifier.md
+++ b/tests/cases/expr/assign/array-identifier.md
@@ -15,22 +15,21 @@
     "span": "0:9",
     "operator": "Assign",
     "left": {
-      "Literal": {
+      "ArrayBinding": {
         "span": "0:5",
-        "literal": {
-          "Array": {
-            "elements": [
-              {
-                "Expr": {
-                  "IdentRef": {
-                    "span": "2:3",
-                    "name": "a"
-                  }
-                }
+        "elements": [
+          {
+            "span": "2:3",
+            "pattern": {
+              "Ident": {
+                "span": "2:3",
+                "name": "a"
               }
-            ]
+            },
+            "initializer": null
           }
-        }
+        ],
+        "rest": null
       }
     },
     "right": {

--- a/tests/cases/expr/assign/array-rest-binding.md
+++ b/tests/cases/expr/assign/array-rest-binding.md
@@ -15,21 +15,12 @@
     "span": "0:15",
     "operator": "Assign",
     "left": {
-      "Literal": {
+      "ArrayBinding": {
         "span": "0:11",
-        "literal": {
-          "Array": {
-            "elements": [
-              {
-                "Spread": {
-                  "IdentRef": {
-                    "span": "5:9",
-                    "name": "rest"
-                  }
-                }
-              }
-            ]
-          }
+        "elements": [],
+        "rest": {
+          "span": "5:9",
+          "name": "rest"
         }
       }
     },


### PR DESCRIPTION
Previously the array pattern on the left aside of an assignment in an expression was a literal:
```
([a, b, c, ...rest] = [1, 2, 3]);
```

Now it's an array binding pattern, which has more strict syntax and uses the correct term "rest" instead of "spread".