### PR TITLE
fix: reader failed init when second char is a non token

### DIFF
--- a/ast/src/span.rs
+++ b/ast/src/span.rs
@@ -23,6 +23,10 @@ impl Span {
             end: (self.end as isize + offset) as usize,
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.start == 0 && self.end == 0
+    }
 }
 
 impl Serialize for Span {

--- a/common/src/io.rs
+++ b/common/src/io.rs
@@ -5,7 +5,7 @@ use std::str::CharIndices;
 
 #[derive(Debug)]
 pub enum Error<E> {
-    EndOfStream(usize),
+    EndOfStream,
     ReaderError(E),
 }
 
@@ -27,7 +27,7 @@ pub trait PeekRead<T> {
     fn read_next_safe(&mut self) -> Result<(usize, T), Self::Error> {
         match self.next() {
             Ok(Some(item)) => Ok(item),
-            Ok(None) => Err(Error::EndOfStream(1)),
+            Ok(None) => Err(Error::EndOfStream),
             Err(error) => Err(Error::ReaderError(error)),
         }
     }
@@ -125,7 +125,7 @@ where
         if let Some((_, current)) = self.current.as_ref() {
             Ok(current)
         } else {
-            Err(Error::EndOfStream(self.position))
+            Err(Error::EndOfStream)
         }
     }
 
@@ -153,7 +153,7 @@ where
             self.position = position + self.offset;
             Ok(item)
         } else {
-            Err(Error::EndOfStream(self.position))
+            Err(Error::EndOfStream)
         }
     }
 }
@@ -176,7 +176,7 @@ where
                         break;
                     }
                 }
-                Err(Error::EndOfStream(_)) => {
+                Err(Error::EndOfStream) => {
                     break;
                 }
                 Err(e) => {

--- a/common/src/io.rs
+++ b/common/src/io.rs
@@ -24,7 +24,7 @@ pub trait PeekRead<T> {
     /// The item is returned in a tuple with the end position as first element.
     fn next(&mut self) -> std::result::Result<Option<(usize, T)>, Self::Error>;
 
-    fn read_next_safe(&mut self) -> Result<(usize, T), Self::Error> {
+    fn read_next(&mut self) -> Result<(usize, T), Self::Error> {
         match self.next() {
             Ok(Some(item)) => Ok(item),
             Ok(None) => Err(Error::EndOfStream),
@@ -73,7 +73,7 @@ where
     pub fn rewind_to(&mut self, item: &T) -> Result<(), E> {
         self.inner.rewind_before(item);
         self.current = self.inner.next()?;
-        self.next = self.inner.read_next_safe();
+        self.next = self.inner.read_next();
         Ok(())
     }
 
@@ -83,7 +83,7 @@ where
             self.inner.rewind_before(token);
 
             self.current = self.inner.read_with_state(state)?;
-            self.next = self.inner.read_next_safe();
+            self.next = self.inner.read_next();
         }
 
         Ok(())
@@ -103,7 +103,7 @@ where
 
     pub fn with_offset(mut inner: I, offset: usize) -> Result<Self, I::Error> {
         let current = inner.next()?;
-        let next = inner.read_next_safe();
+        let next = inner.read_next();
 
         Ok(PeekReader {
             inner,
@@ -143,7 +143,7 @@ where
     /// Consuming passed the end of stream results in EndOfStream error.
     /// Any errors from the inner reader while reading will also result in an error.
     pub fn consume(&mut self) -> Result<T, I::Error> {
-        let mut next = self.inner.read_next_safe();
+        let mut next = self.inner.read_next();
         mem::swap(&mut next, &mut self.next);
 
         let mut current = next.ok();

--- a/lexer/src/error.rs
+++ b/lexer/src/error.rs
@@ -23,9 +23,9 @@ pub enum ErrorKind {
 }
 
 impl Error {
-    pub fn unexpected_end_of_stream(pos: usize) -> Self {
+    pub fn unexpected_end_of_stream() -> Self {
         Error {
-            span: Span::new(pos, pos),
+            span: Span::empty(),
             kind: EndOfStream,
         }
     }
@@ -79,7 +79,7 @@ impl error::Error for Error {}
 impl From<CommonError<()>> for Error {
     fn from(error: CommonError<()>) -> Self {
         match error {
-            CommonError::EndOfStream(pos) => Error::unexpected_end_of_stream(pos),
+            CommonError::EndOfStream => Error::unexpected_end_of_stream(),
             CommonError::ReaderError(_) => unreachable!(),
         }
     }

--- a/lexer/src/error.rs
+++ b/lexer/src/error.rs
@@ -1,3 +1,4 @@
+use crate::error::ErrorKind::{ForbiddenIdentifier, UnrecognizedCodePoint};
 use crate::token::Keyword;
 use crate::{EndOfStream, InvalidOrUnexpectedToken, Token};
 use fajt_ast::Span;
@@ -17,6 +18,7 @@ pub struct Error {
 pub enum ErrorKind {
     InvalidOrUnexpectedToken(Token),
     ForbiddenIdentifier(Keyword),
+    UnrecognizedCodePoint(char),
     EndOfStream,
 }
 
@@ -35,6 +37,13 @@ impl Error {
         }
     }
 
+    pub fn unrecognized_code_point<S: Into<Span>>(char: char, span: S) -> Self {
+        Error {
+            span: span.into(),
+            kind: UnrecognizedCodePoint(char),
+        }
+    }
+
     pub fn span(&self) -> &Span {
         &self.span
     }
@@ -47,16 +56,19 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            ErrorKind::EndOfStream => write!(f, "Unexpected end of stream"),
-            ErrorKind::InvalidOrUnexpectedToken(t) => {
+            EndOfStream => write!(f, "Unexpected end of stream"),
+            InvalidOrUnexpectedToken(t) => {
                 write!(f, "Invalid or unexpected token {:?}", t)
             }
-            ErrorKind::ForbiddenIdentifier(k) => {
+            ForbiddenIdentifier(k) => {
                 write!(
                     f,
                     "Keyword '{:?}' is not allowed as identifier in this context.",
                     k
                 )
+            }
+            UnrecognizedCodePoint(char) => {
+                write!(f, "Unknown code point {char}")
             }
         }
     }

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -53,7 +53,7 @@ macro_rules! produce {
         Ok($produce)
     }};
     ($self:ident, peek: $peek:literal ? $product1:expr ; $product2:expr) => {{
-        if $self.reader.peek() == Some(&$peek) {
+        if $self.reader.peek().ok() == Some(&$peek) {
             produce!($self, 2, $product1)
         } else {
             produce!($self, 1, $product2)
@@ -113,7 +113,7 @@ impl<'a> Lexer<'a> {
         let value = match current {
             // <op>=
             '/' | '*' | '%' | '+' | '-' | '|' | '^' | '&' | '<' | '>' | '='
-                if self.reader.peek() == Some(&'=') =>
+                if self.reader.peek().ok() == Some(&'=') =>
             {
                 match current {
                     '/' => produce!(self, 2, punct!("/=")),
@@ -133,22 +133,22 @@ impl<'a> Lexer<'a> {
                     _ => unreachable!(),
                 }
             }
-            '<' if self.reader.peek() == Some(&'<') => {
+            '<' if self.reader.peek().ok() == Some(&'<') => {
                 self.reader.consume()?;
                 produce!(self, peek: '=' ? punct!("<<=") ; punct!("<<"))
             }
-            '>' if self.reader.peek() == Some(&'>') => {
+            '>' if self.reader.peek().ok() == Some(&'>') => {
                 self.reader.consume()?;
                 match self.reader.peek() {
-                    Some(&'>') => {
+                    Ok(&'>') => {
                         self.reader.consume()?;
                         produce!(self, peek: '=' ? punct!(">>>=") ; punct!(">>>"))
                     }
-                    Some(&'=') => produce!(self, 2, punct!(">>=")),
+                    Ok(&'=') => produce!(self, 2, punct!(">>=")),
                     _ => produce!(self, 1, punct!(">>")),
                 }
             }
-            '!' if self.reader.peek() == Some(&'=') => {
+            '!' if self.reader.peek().ok() == Some(&'=') => {
                 self.reader.consume()?;
                 produce!(self, peek: '=' ? punct!("!==") ; punct!("!="))
             }
@@ -175,7 +175,7 @@ impl<'a> Lexer<'a> {
             '?' => {
                 self.reader.consume()?;
                 Ok(match self.reader.current() {
-                    Ok(&'.') if !matches!(self.reader.peek(), Some('0'..='9')) => {
+                    Ok(&'.') if !matches!(self.reader.peek(), Ok('0'..='9')) => {
                         self.reader.consume()?;
                         punct!("?.")
                     }
@@ -187,7 +187,7 @@ impl<'a> Lexer<'a> {
                 })
             }
             '*' => {
-                if self.reader.peek() == Some(&'*') {
+                if self.reader.peek().ok() == Some(&'*') {
                     self.reader.consume()?;
                     produce!(self, peek: '=' ? punct!("**=") ; punct!("**"))
                 } else {
@@ -195,9 +195,9 @@ impl<'a> Lexer<'a> {
                 }
             }
             '.' => {
-                if self.reader.peek() == Some(&'.') {
+                if self.reader.peek().ok() == Some(&'.') {
                     self.reader.consume()?;
-                    if self.reader.peek() == Some(&'.') {
+                    if self.reader.peek().ok() == Some(&'.') {
                         produce!(self, 2, punct!("..."))
                     } else {
                         let end = self.reader.position();
@@ -229,13 +229,13 @@ impl<'a> Lexer<'a> {
             skipped_new_line = self.skip_whitespaces()? || skipped_new_line;
 
             match self.reader.current() {
-                Ok('/') if self.reader.peek() == Some(&'/') => {
+                Ok('/') if self.reader.peek().ok() == Some(&'/') => {
                     self.skip_single_line_comment();
                     // Single line comments never includes the ending new line. If at end of file it
                     // doesn't matter if we lie and say there was a new line.
                     skipped_new_line = true;
                 }
-                Ok('/') if self.reader.peek() == Some(&'*') => {
+                Ok('/') if self.reader.peek().ok() == Some(&'*') => {
                     skipped_new_line = self.skip_multi_line_comment()? || skipped_new_line;
                 }
                 _ => break,
@@ -268,7 +268,7 @@ impl<'a> Lexer<'a> {
         let mut contains_line_break = false;
         let mut content = String::new();
         loop {
-            if matches!(self.reader.current(), Ok('*')) && self.reader.peek() == Some(&'/') {
+            if matches!(self.reader.current(), Ok('*')) && self.reader.peek().ok() == Some(&'/') {
                 self.reader.consume()?;
                 self.reader.consume()?;
                 break;
@@ -404,13 +404,13 @@ impl<'a> Lexer<'a> {
     fn read_number_literal(&mut self) -> Result<TokenValue> {
         let current = self.reader.current()?;
         let (base, number) = match self.reader.peek() {
-            Some(&'x' | &'X') if current == &'0' => {
+            Ok(&'x' | &'X') if current == &'0' => {
                 (Hex, self.read_number(16, char::is_ascii_hexdigit)?)
             }
-            Some(&'o' | &'O') if current == &'0' => {
+            Ok(&'o' | &'O') if current == &'0' => {
                 (Octal, self.read_number(8, |c| ('0'..='7').contains(c))?)
             }
-            Some(&'b' | &'B') if current == &'0' => {
+            Ok(&'b' | &'B') if current == &'0' => {
                 (Binary, self.read_number(2, |c| c == &'0' || c == &'1')?)
             }
             _ => {

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -559,7 +559,7 @@ impl ReReadWithState<Token> for Lexer<'_> {
 }
 
 impl PeekRead<Token> for Lexer<'_> {
-    type Error = error::Error;
+    type Error = Error;
 
     fn next(&mut self) -> std::result::Result<Option<(usize, Token)>, Error> {
         match self.read() {

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -214,7 +214,7 @@ impl<'a> Lexer<'a> {
             '"' | '\'' => self.read_string_literal(),
             '`' => self.read_template_literal_head(),
             c if c.is_start_of_identifier() => self.read_identifier_or_keyword(),
-            c => unimplemented!("Lexer did not recognize code point '{}'.", c),
+            c => return Err(Error::unrecognized_code_point(*c, (start, start + 1))),
         }?;
         let end = self.reader.position();
 

--- a/parser/src/error/emitter.rs
+++ b/parser/src/error/emitter.rs
@@ -25,11 +25,16 @@ impl<'a, 'b, 'c, W: Write> ErrorEmitter<'a, 'b, 'c, W> {
         let line_number = self.get_line_number(span);
 
         writeln!(self.out, "{}", error)?;
-        writeln!(
-            self.out,
-            " --> {}:{}:{}",
-            self.filename, line_number, col_number
-        )?;
+
+        if span.is_empty() {
+            writeln!(self.out, " --> {}", self.filename)?;
+        } else {
+            writeln!(
+                self.out,
+                " --> {}:{}:{}",
+                self.filename, line_number, col_number
+            )?;
+        }
 
         if error.kind != ErrorKind::EndOfStream {
             let label = self.get_kind_description(error);

--- a/parser/src/error/mod.rs
+++ b/parser/src/error/mod.rs
@@ -79,10 +79,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn end_of_stream(pos: usize) -> Self {
+    pub(crate) fn end_of_stream() -> Self {
         Error {
             kind: EndOfStream,
-            span: Span::new(pos, pos),
+            span: Span::empty(),
         }
     }
 
@@ -140,7 +140,7 @@ impl From<LexerError> for Error {
 impl From<CommonError<LexerError>> for Error {
     fn from(error: CommonError<LexerError>) -> Self {
         match error {
-            CommonError::EndOfStream(pos) => Error::end_of_stream(pos),
+            CommonError::EndOfStream => Error::end_of_stream(),
             CommonError::ReaderError(lexer_error) => lexer_error.into(),
         }
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -238,7 +238,7 @@ where
     }
 
     fn peek(&self) -> Option<&Token> {
-        self.reader.peek()
+        self.reader.peek().ok()
     }
 
     fn is_end(&self) -> bool {

--- a/tests/cases/expr/regexp/regexp-unknown-codepoint.md
+++ b/tests/cases/expr/regexp/regexp-unknown-codepoint.md
@@ -1,0 +1,11 @@
+### Source
+Regexp may contain code points that are not recognized by the parser.
+This catches that edge case.
+
+```js check-format:no
+/#/;
+/@/;
+/☂/;
+```
+
+### Output: ast

--- a/tests/cases/expr/regexp/regexp-unknown-codepoint.md
+++ b/tests/cases/expr/regexp/regexp-unknown-codepoint.md
@@ -9,3 +9,52 @@ This catches that edge case.
 ```
 
 ### Output: ast
+```json
+{
+  "Script": {
+    "span": "0:16",
+    "directives": [],
+    "body": [
+      {
+        "Expr": {
+          "span": "0:4",
+          "expr": {
+            "Literal": {
+              "span": "0:3",
+              "literal": {
+                "Regexp": "/#/"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Expr": {
+          "span": "5:9",
+          "expr": {
+            "Literal": {
+              "span": "5:8",
+              "literal": {
+                "Regexp": "/@/"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Expr": {
+          "span": "10:16",
+          "expr": {
+            "Literal": {
+              "span": "10:15",
+              "literal": {
+                "Regexp": "/☂/"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```

--- a/tests/cases/expr/update/postfix-decrease-no-new-line.md
+++ b/tests/cases/expr/update/postfix-decrease-no-new-line.md
@@ -7,5 +7,5 @@ a
 ### Output: error
 ```txt
 Syntax error: Unexpected end of input
- --> test.js:2:3
+ --> test.js
 ```

--- a/tests/cases/expr/update/postfix-increase-no-new-line.md
+++ b/tests/cases/expr/update/postfix-increase-no-new-line.md
@@ -7,5 +7,5 @@ a
 ### Output: error
 ```txt
 Syntax error: Unexpected end of input
- --> test.js:2:3
+ --> test.js
 ```


### PR DESCRIPTION
Failed to read regexp because lexer returned error that code point is unrecognized, which unwound all the way up to stop fail the application.